### PR TITLE
Align hex to right, use remotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# The {creepr} R package: it's just {beepr} but scary
-<img src="inst/hexsticker/hexsticker.png" height="300"/>
+# The {creepr} R package: it's just {beepr} but scary <img src="inst/hexsticker/hexsticker.png" align="right" height="138"/>
 
 For those unfamiliar with {beepr} the `beepr::beepr()` command tells the machine to make a noise. This package is very similar but the `creepr::creepr()` command will make you really scared.
 
@@ -7,9 +6,9 @@ For those unfamiliar with {beepr} the `beepr::beepr()` command tells the machine
 
 You can install {creepr} in the following way
 
-```
-install.packages("devtools")
-devtools::install_github("jcken95/creepr")
+```r
+# install.packages("remotes")
+remotes::install_github("jcken95/creepr")
 ```
 
 {creepr} is not yet on CRAN, and I have no plans to put it on CRAN anytime soon. 


### PR DESCRIPTION
* Add the `align` argument for the hex sticker and move it so it's on the right hand side of the readme.
